### PR TITLE
Move Mouse & AbsoluteMouse initialization to MouseWrapper.begin

### DIFF
--- a/src/Kaleidoscope-MouseKeys.cpp
+++ b/src/Kaleidoscope-MouseKeys.cpp
@@ -112,6 +112,7 @@ MouseKeys_::MouseKeys_(void) {
 
 void
 MouseKeys_::begin(void) {
+  MouseWrapper.begin();
   event_handler_hook_use(eventHandlerHook);
   loop_hook_use(loopHook);
 }

--- a/src/MouseWrapper.cpp
+++ b/src/MouseWrapper.cpp
@@ -14,6 +14,9 @@ boolean MouseWrapper_::is_warping;
 uint8_t MouseWrapper_::accelStep;
 
 MouseWrapper_::MouseWrapper_(void) {
+}
+
+void MouseWrapper_::begin(void) {
   kaleidoscope::hid::initializeMouse();
   kaleidoscope::hid::initializeAbsoluteMouse();
 }

--- a/src/MouseWrapper.h
+++ b/src/MouseWrapper.h
@@ -31,6 +31,7 @@ class MouseWrapper_ {
  public:
   MouseWrapper_(void);
 
+  static void begin(void);
   static void move(int8_t x, int8_t y);
   static void warp(uint8_t warp_cmd);
   static void pressButton(uint8_t button);


### PR DESCRIPTION
To avoid issues with static initialization order, move the Mouse & AbsoluteMouse initialization from the MouseWrapper constructor to MouseWrapper.begin, which will be called from MouseKeys.begin. Thus, user code does not need to change.

This fixes keyboardio/Kaleidoscope#140.

Thanks a lot to @wez for pointing at SIOF - it was indeed as he said.