### PR TITLE
Upgraded mouse acceleration.

### DIFF
--- a/src/Kaleidoscope-MouseKeys.cpp
+++ b/src/Kaleidoscope-MouseKeys.cpp
@@ -7,10 +7,10 @@
 uint8_t MouseKeys_::mouseMoveIntent;
 
 uint8_t MouseKeys_::speed = 1;
-uint16_t MouseKeys_::speedDelay = 0;
+uint16_t MouseKeys_::speedDelay = 1;
 
 uint8_t MouseKeys_::accelSpeed = 1;
-uint16_t MouseKeys_::accelDelay = 50;
+uint16_t MouseKeys_::accelDelay = 64;
 
 uint8_t MouseKeys_::wheelSpeed = 1;
 uint16_t MouseKeys_::wheelDelay = 50;

--- a/src/MouseWrapper.cpp
+++ b/src/MouseWrapper.cpp
@@ -12,6 +12,7 @@ uint16_t MouseWrapper_::section_left;
 boolean MouseWrapper_::is_warping;
 
 uint8_t MouseWrapper_::accelStep;
+uint8_t MouseWrapper_::speedLimit = 127;
 
 MouseWrapper_::MouseWrapper_(void) {
 }
@@ -79,23 +80,20 @@ void MouseWrapper_::warp(uint8_t warp_cmd) {
 }
 
 // cubic wave function based on code from FastLED
+// produces a shape similar to a sine curve from 0 to 255
+// (slow growth at 0, fast growth in the middle, slow growth at 255)
+// http://www.wolframalpha.com/input/?i=((3((x)**2)%2F256)+-+((2((x)(x)(x%2F256))%2F256)))+%2B+1
 uint8_t MouseWrapper_::acceleration(uint8_t cycles) {
-  uint8_t i = cycles;
+  uint16_t i = cycles;
 
-  if (i & 0x80) {
-    i = 255 - i;
-  }
+  uint16_t ii = (i * i) >> 8;
+  uint16_t iii = (ii * i) >> 8;
 
-  i = i << 1;
+  i = ((3 * ii) - (2 * iii)) + 1;
 
-  uint8_t ii = (i * i) >> 8;
-  uint8_t iii = (ii * i) >> 8;
+  // Just in case (may go up to 256 at peak)
+  if (i > 255) i = 255;
 
-  i = (((3 * (uint16_t)(ii)) - (2 * (uint16_t)(iii))) / 2) + ACCELERATION_FLOOR;
-
-  if (i > ACCELERATION_CEIL) {
-    i = ACCELERATION_CEIL;
-  }
   return i;
 }
 
@@ -103,15 +101,25 @@ uint8_t MouseWrapper_::acceleration(uint8_t cycles) {
 void MouseWrapper_::move(int8_t x, int8_t y) {
   int16_t moveX = 0;
   int16_t moveY = 0;
+  static int8_t remainderX = 0;
+  static int8_t remainderY = 0;
   if (x != 0) {
-    moveX = (x * acceleration(accelStep));
+    moveX = remainderX + (x * acceleration(accelStep));
+    if (moveX > (int16_t)speedLimit) moveX = speedLimit;
+    else if (moveX < -(int16_t)speedLimit) moveX = -speedLimit;
   }
   if (y != 0) {
-    moveY = (y * acceleration(accelStep));
+    moveY = remainderY + (y * acceleration(accelStep));
+    if (moveY > (int16_t)speedLimit) moveY = speedLimit;
+    else if (moveY < -(int16_t)speedLimit) moveY = -speedLimit;
   }
 
   end_warping();
-  kaleidoscope::hid::moveMouse(moveX, moveY, 0);
+  // move by whole pixels, not subpixels
+  kaleidoscope::hid::moveMouse(moveX>>4, moveY>>4, 0);
+  // save leftover subpixel movements for later
+  remainderX = moveX & 0x0f;
+  remainderY = moveY & 0x0f;
 }
 
 MouseWrapper_ MouseWrapper;

--- a/src/MouseWrapper.cpp
+++ b/src/MouseWrapper.cpp
@@ -116,7 +116,7 @@ void MouseWrapper_::move(int8_t x, int8_t y) {
 
   end_warping();
   // move by whole pixels, not subpixels
-  kaleidoscope::hid::moveMouse(moveX>>4, moveY>>4, 0);
+  kaleidoscope::hid::moveMouse(moveX >> 4, moveY >> 4, 0);
   // save leftover subpixel movements for later
   remainderX = moveX & 0x0f;
   remainderY = moveY & 0x0f;

--- a/src/MouseWrapper.h
+++ b/src/MouseWrapper.h
@@ -22,11 +22,6 @@
 
 // Mouse acceleration
 
-// we want the whole s curve, not just the bit
-// that's usually above the x and y axes;
-#define ACCELERATION_FLOOR 2
-#define ACCELERATION_CEIL 50
-
 class MouseWrapper_ {
  public:
   MouseWrapper_(void);
@@ -37,6 +32,7 @@ class MouseWrapper_ {
   static void pressButton(uint8_t button);
   static void release_button(uint8_t button);
   static uint8_t accelStep;
+  static uint8_t speedLimit;
 
  private:
   static uint16_t next_width;


### PR DESCRIPTION
Fixes https://github.com/keyboardio/Kaleidoscope-MouseKeys/issues/7 .

Uses mickeys (1/16th subpixel units) now instead of pixels.  Much smoother!
Added "speedLimit" config var to set maximum cursor speed.
Ensured default values are sane.