### PR TITLE
Update for compatibility with Kaleidoscope-Hardware-Virtual

### DIFF
--- a/src/MouseWrapper.h
+++ b/src/MouseWrapper.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Arduino.h"
-#include "KeyboardioHID.h"
 
 // Warping commands
 


### PR DESCRIPTION
This fix follows exactly the pattern in keyboardio/Kaleidoscope/src/kaleidoscope/hid.cpp for exactly the same problem re: Hardware-Virtual builds.