### PR TITLE
Fix warping while dragging the mouse

### DIFF
--- a/src/Kaleidoscope-MouseKeys.cpp
+++ b/src/Kaleidoscope-MouseKeys.cpp
@@ -83,6 +83,12 @@ Key MouseKeys_::eventHandlerHook(Key mappedKey, byte row, byte col, uint8_t keyS
     uint8_t button = mappedKey.keyCode & ~KEY_MOUSE_BUTTON;
 
     if (keyIsPressed(keyState)) {
+      // Reset warp state on initial mouse button key-down only so we can use
+      // warp keys to drag-and-drop:
+      if (keyToggledOn(keyState)) {
+        MouseWrapper.reset_warping();
+      }
+
       MouseWrapper.pressButton(button);
     } else if (keyToggledOff(keyState)) {
       MouseWrapper.release_button(button);

--- a/src/MouseWrapper.cpp
+++ b/src/MouseWrapper.cpp
@@ -24,11 +24,11 @@ void MouseWrapper_::begin(void) {
 
 void MouseWrapper_::pressButton(uint8_t button) {
   kaleidoscope::hid::pressMouseButtons(button);
-  end_warping();
 }
 
 void MouseWrapper_::release_button(uint8_t button) {
   kaleidoscope::hid::releaseMouseButtons(button);
+  end_warping();
 }
 
 void MouseWrapper_::warp_jump(uint16_t left, uint16_t top, uint16_t height, uint16_t width) {
@@ -47,6 +47,12 @@ void MouseWrapper_::begin_warping() {
 
 void MouseWrapper_::end_warping() {
   is_warping = false;
+}
+
+void MouseWrapper_::reset_warping() {
+  if (is_warping == true) {
+    begin_warping();
+  }
 }
 
 void MouseWrapper_::warp(uint8_t warp_cmd) {

--- a/src/MouseWrapper.h
+++ b/src/MouseWrapper.h
@@ -28,6 +28,7 @@ class MouseWrapper_ {
   static void begin(void);
   static void move(int8_t x, int8_t y);
   static void warp(uint8_t warp_cmd);
+  static void reset_warping();
   static void pressButton(uint8_t button);
   static void release_button(uint8_t button);
   static uint8_t accelStep;


### PR DESCRIPTION
As described in #15, we cannot currently warp into a sub-cell while holding a mouse button (like we would when dragging an item). This change fixes the issue by: 

  - Calling `end_warping()` when we *release* a mouse button (instead of when we press it)
  - Resetting the warp state on the initial button press (to get a new warp context when we start dragging)