### PR TITLE
Reset the acceleration timer each time it expires.

### DIFF
--- a/src/Kaleidoscope-MouseKeys.cpp
+++ b/src/Kaleidoscope-MouseKeys.cpp
@@ -62,8 +62,10 @@ void MouseKeys_::loopHook(bool postClear) {
   int8_t moveX = 0, moveY = 0;
 
   if (millis() >= accelEndTime) {
-    if (MouseWrapper.accelStep < 255 - accelSpeed)
+    if (MouseWrapper.accelStep < 255 - accelSpeed) {
       MouseWrapper.accelStep += accelSpeed;
+    }
+    accelEndTime = millis() + accelDelay;
   }
 
   if (mouseMoveIntent & KEY_MOUSE_UP)


### PR DESCRIPTION
Without this, once the timeout expires the first time, every time
through the loop triggers acceleration, which rapidly becomes
excessive.