### PR TITLE
Apply correct diagonal movement speeds, fix remainder calculation

### DIFF
--- a/src/MouseWrapper.cpp
+++ b/src/MouseWrapper.cpp
@@ -112,24 +112,19 @@ uint8_t MouseWrapper_::acceleration(uint8_t cycles) {
   return i;
 }
 
-static int8_t roundAwayFromZero(float value) {
-  if (value < 0.0f) {
-    return static_cast<int8_t>(value - 0.5f);
-  }
-
-  return static_cast<int8_t>(value + 0.5f);
-}
-
 void MouseWrapper_::move(int8_t x, int8_t y) {
   int16_t moveX = 0;
   int16_t moveY = 0;
   static int8_t remainderX = 0;
   static int8_t remainderY = 0;
-  static const float HALF_SQRT_2 = 0.7071f;
 
   if (x != 0 && y != 0) {
-    x = roundAwayFromZero(HALF_SQRT_2 * x);
-    y = roundAwayFromZero(HALF_SQRT_2 * y);
+    // 99 / 140 closely approximates sqrt(2) / 2.
+    int8_t adjusted_x = x * 99 / 140;
+    int8_t adjusted_y = y * 99 / 140;
+
+    x = (adjusted_x == 0 ? x : adjusted_x);
+    y = (adjusted_y == 0 ? y : adjusted_y);
   }
 
   if (x != 0) {

--- a/src/MouseWrapper.cpp
+++ b/src/MouseWrapper.cpp
@@ -119,12 +119,13 @@ void MouseWrapper_::move(int8_t x, int8_t y) {
   static int8_t remainderY = 0;
 
   if (x != 0 && y != 0) {
-    // 99 / 140 closely approximates sqrt(2) / 2.
-    int8_t adjusted_x = x * 99 / 140;
-    int8_t adjusted_y = y * 99 / 140;
+    // 99 / 140 closely approximates sqrt(2) / 2. Since integer division
+    // truncates towards zero we do not need to worry about truncation errors.
+    int8_t adjustedX = (int16_t)x * 99 / 140;
+    int8_t adjustedY = (int16_t)y * 99 / 140;
 
-    x = (adjusted_x == 0 ? x : adjusted_x);
-    y = (adjusted_y == 0 ? y : adjusted_y);
+    if (adjustedX != 0) x = adjustedX;
+    if (adjustedY != 0) y = adjustedY;
   }
 
   if (x != 0) {

--- a/src/MouseWrapper.cpp
+++ b/src/MouseWrapper.cpp
@@ -112,19 +112,34 @@ uint8_t MouseWrapper_::acceleration(uint8_t cycles) {
   return i;
 }
 
+static int8_t roundAwayFromZero(float value) {
+  if (value < 0.0f) {
+    return static_cast<int8_t>(value - 0.5f);
+  }
+
+  return static_cast<int8_t>(value + 0.5f);
+}
 
 void MouseWrapper_::move(int8_t x, int8_t y) {
   int16_t moveX = 0;
   int16_t moveY = 0;
   static int8_t remainderX = 0;
   static int8_t remainderY = 0;
+  static const float HALF_SQRT_2 = 0.7071f;
+
+  boolean isDiagonal = (x != 0 && y != 0);
+
   if (x != 0) {
+    if (isDiagonal) x = roundAwayFromZero(HALF_SQRT_2 * x);
     moveX = remainderX + (x * acceleration(accelStep));
+
     if (moveX > (int16_t)speedLimit) moveX = speedLimit;
     else if (moveX < -(int16_t)speedLimit) moveX = -speedLimit;
   }
   if (y != 0) {
+    if (isDiagonal) y = roundAwayFromZero(HALF_SQRT_2 * y);
     moveY = remainderY + (y * acceleration(accelStep));
+
     if (moveY > (int16_t)speedLimit) moveY = speedLimit;
     else if (moveY < -(int16_t)speedLimit) moveY = -speedLimit;
   }

--- a/src/MouseWrapper.cpp
+++ b/src/MouseWrapper.cpp
@@ -127,19 +127,18 @@ void MouseWrapper_::move(int8_t x, int8_t y) {
   static int8_t remainderY = 0;
   static const float HALF_SQRT_2 = 0.7071f;
 
-  boolean isDiagonal = (x != 0 && y != 0);
+  if (x != 0 && y != 0) {
+    x = roundAwayFromZero(HALF_SQRT_2 * x);
+    y = roundAwayFromZero(HALF_SQRT_2 * y);
+  }
 
   if (x != 0) {
-    if (isDiagonal) x = roundAwayFromZero(HALF_SQRT_2 * x);
     moveX = remainderX + (x * acceleration(accelStep));
-
     if (moveX > (int16_t)speedLimit) moveX = speedLimit;
     else if (moveX < -(int16_t)speedLimit) moveX = -speedLimit;
   }
   if (y != 0) {
-    if (isDiagonal) y = roundAwayFromZero(HALF_SQRT_2 * y);
     moveY = remainderY + (y * acceleration(accelStep));
-
     if (moveY > (int16_t)speedLimit) moveY = speedLimit;
     else if (moveY < -(int16_t)speedLimit) moveY = -speedLimit;
   }

--- a/src/MouseWrapper.h
+++ b/src/MouseWrapper.h
@@ -34,6 +34,7 @@ class MouseWrapper_ {
   static void release_button(uint8_t button);
   static uint8_t accelStep;
   static uint8_t speedLimit;
+  static uint8_t subpixelsPerPixel;
   static uint8_t warp_grid_size;
 
  private:


### PR DESCRIPTION
For diagonal movements in `MouseWrapper_::move()`, i.e. with `x != 0 && y != 0`, divide the movement speeds by sqrt(2) / 2. This makes the diagonal movement speeds a little more predictable.

The `roundAwayFromZero` function was added to make sure that if we end up with a speed of something like -0.9 that we still round it up to -1.0, because otherwise at low speeds the cursor will not move at all.

```
Previously, diagonal movements were not reduced in the two axes,
resulting in movement that was too quick. This commit divides diagonal
movements by sqrt(2) / 2 to correct the movement speed.

The net result is that diagonal movement should feel smoother and speed
more as expected.
```