### PR TITLE
Add support for setting speedLimit on MouseKeys

### DIFF
--- a/src/Kaleidoscope-MouseKeys.cpp
+++ b/src/Kaleidoscope-MouseKeys.cpp
@@ -19,6 +19,8 @@ uint32_t MouseKeys_::accelEndTime;
 uint32_t MouseKeys_::endTime;
 uint32_t MouseKeys_::wheelEndTime;
 
+uint8_t& MouseKeys_::speedLimit = MouseWrapper_::speedLimit;
+
 void MouseKeys_::setWarpGridSize(uint8_t grid_size) {
   MouseWrapper.warp_grid_size = grid_size;
 }

--- a/src/Kaleidoscope-MouseKeys.h
+++ b/src/Kaleidoscope-MouseKeys.h
@@ -14,6 +14,7 @@ class MouseKeys_ : public kaleidoscope::Plugin {
   static uint16_t accelDelay;
   static uint8_t wheelSpeed;
   static uint16_t wheelDelay;
+  static uint8_t& speedLimit;
 
   static void setWarpGridSize(uint8_t grid_size);
 


### PR DESCRIPTION
Add a reference to `MouseWrapper_`'s speed limit member on `MouseKeys_` so we can do something like `MouseKeys.speedLimit = 32;` and have it propagate to `MouseWrapper_`.

Fixes #20.