### PR TITLE
Add setSpeedLimit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ properties available:
 > wheel shall scroll, and defaults to 1. The second, `.wheelDelay`, controls the
 > delay between two scroll events, and defaults to 50 milliseconds.
 
+### `.setSpeedLimit`
+
+> This method sets the maximum speed after which acceleration stops.
+> The default is 127, and the minimum value is 16 (things will not work
+> properly below 16).
+
 ### `.setWarpGridSize`
 
 > This method changes the size of the grid used for [warping](#warping). The

--- a/src/Kaleidoscope-MouseKeys.cpp
+++ b/src/Kaleidoscope-MouseKeys.cpp
@@ -23,6 +23,10 @@ void MouseKeys_::setWarpGridSize(uint8_t grid_size) {
   MouseWrapper.warp_grid_size = grid_size;
 }
 
+void MouseKeys_::setSpeedLimit(uint8_t speed_limit) {
+  MouseWrapper.speedLimit = speed_limit;
+}
+
 void MouseKeys_::scrollWheel(uint8_t keyCode) {
   if (millis() < wheelEndTime)
     return;

--- a/src/Kaleidoscope-MouseKeys.h
+++ b/src/Kaleidoscope-MouseKeys.h
@@ -16,6 +16,7 @@ class MouseKeys_ : public kaleidoscope::Plugin {
   static uint16_t wheelDelay;
 
   static void setWarpGridSize(uint8_t grid_size);
+  static void setSpeedLimit(uint8_t speed_limit);
 
   kaleidoscope::EventHandlerResult onSetup();
   kaleidoscope::EventHandlerResult beforeReportingState();


### PR DESCRIPTION
This adds a new method `MouseKeys.setSpeedLimit(uint8_t)` that can be used to further tune mouse behavior. The method simply exposes the already-existing functionality in `MouseWrapper`.

Personally I found the default of 127 to be way too fast, and instead set the speed limit to 32 in my sketch. Maybe other people will find it useful too.